### PR TITLE
Add demo data buttons

### DIFF
--- a/src/app/tab/bussiness-idea/bussiness-idea.component.html
+++ b/src/app/tab/bussiness-idea/bussiness-idea.component.html
@@ -11,6 +11,9 @@
       <button (click)="generatePDF()" class="btn btn-primary">
         <i class="fas fa-file-download"></i> PDF
       </button>
+      <button (click)="fillDemoData()" class="btn btn-secondary ml-2">
+        Show Demo Data
+      </button>
     </div>
   </section>
   <!-- Skills & Experience Section -->

--- a/src/app/tab/bussiness-idea/bussiness-idea.component.ts
+++ b/src/app/tab/bussiness-idea/bussiness-idea.component.ts
@@ -330,6 +330,23 @@ console.log(formData)
       }
     });
   }
+
+  fillDemoData() {
+    this.businessData = {
+      Skills_Experience: 'Web development\nProject management\nGraphic design',
+      Passions_Interests: 'Technology\nArt\nEducation',
+      Values_Goals: 'Innovation\nCreativity\nCommunity support',
+      Personal_notes: 'Remember to validate ideas\nResearch competitors'
+    };
+
+    this.businessIdeas = {
+      idea1: 'Online coding bootcamp',
+      idea2: 'Graphic design studio',
+      idea3: 'Project management tool',
+      idea4: 'Tech blog',
+      idea5: 'Educational app'
+    };
+  }
 //   getBussinesIdea() {
 //     this.apisService.getBussinessIdea().subscribe((res) => {
 //       if (res) {

--- a/src/app/tab/market-research/market-research.component.html
+++ b/src/app/tab/market-research/market-research.component.html
@@ -6,6 +6,9 @@
 
   </div>
     <p class="video-description">{{videoDescription}}</p>
+    <div class="mt-2">
+      <button (click)="fillDemoData()" class="btn btn-secondary">Show Demo Data</button>
+    </div>
   </section>
   <!-- Target Customer Persona Section -->
   <section class="form-section">

--- a/src/app/tab/market-research/market-research.component.ts
+++ b/src/app/tab/market-research/market-research.component.ts
@@ -349,4 +349,26 @@ saveProgress() {
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
+  fillDemoData() {
+    this.customerPersona = {
+      name: 'Sarah',
+      age: 'Young',
+      gender: 'Female',
+      socialStatus: 'Single',
+      income: 'Medium',
+      employment: 'Full-time',
+      other: 'Lives in city',
+      Personal_notes: 'Likes eco friendly products',
+      defineClients: 'Young professionals',
+      defineProblem: 'Limited healthy lunch options',
+      defineSolution: 'Affordable healthy meal delivery'
+    };
+
+    this.customerChallenges = {
+      MustHaveSolutions: [{ id: 0, text: 'Affordable price' }],
+      ShouldHaveSolutions: [{ id: 0, text: 'Fast delivery' }],
+      NiceToHaveSolutions: [{ id: 0, text: 'Vegan options' }]
+    };
+  }
+
 }

--- a/src/app/tab/mvp/mvp.component.html
+++ b/src/app/tab/mvp/mvp.component.html
@@ -6,6 +6,9 @@
   
     </div>
       <p class="video-description">{{videoDescription}}</p>
+      <div class="mt-2">
+        <button (click)="fillDemoData()" class="btn btn-secondary">Show Demo Data</button>
+      </div>
     </section>
    
     <!-- <div class="business bg-white p-4 rounded-lg shadow space-y-4">

--- a/src/app/tab/mvp/mvp.component.ts
+++ b/src/app/tab/mvp/mvp.component.ts
@@ -234,7 +234,7 @@ isSaved=true
     
 }
 
-openSuggestionDialog1() {
+  openSuggestionDialog1() {
   const dialogRef = this.dialog.open(MvpSuggestionComponent, {
     data: {
      
@@ -329,11 +329,24 @@ openSuggestionDialog4() {
 
   dialogRef.afterClosed().subscribe(result => {
     if (result) {
-    
+
      this.mvp.answer_questions=result
     }
   });
 
+}
+
+fillDemoData() {
+  this.mvp = {
+    big_solution: 'Easy meal planning app',
+    entry_strategy: 'Start with a small beta launch',
+    things_have: 'Cooking skills',
+    things_need: 'Mobile developer',
+    questions: 'What features do users need?',
+    answer_questions: 'Survey a sample of users',
+    future_plan: 'Expand to subscription model',
+    notes: 'Keep the interface simple'
+  };
 }
 
 }

--- a/src/app/tab/new-business-setup/new-business-setup.component.html
+++ b/src/app/tab/new-business-setup/new-business-setup.component.html
@@ -6,6 +6,9 @@
   
     </div>
       <p class="video-description">{{videoDescription}}</p>
+      <div class="mt-2">
+        <button (click)="fillDemoData()" class="btn btn-secondary">Show Demo Data</button>
+      </div>
     </section>
 
     <!-- Legal Structure Section -->

--- a/src/app/tab/new-business-setup/new-business-setup.component.ts
+++ b/src/app/tab/new-business-setup/new-business-setup.component.ts
@@ -66,6 +66,12 @@ notes :string =""
   scrollToTop(): void {
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
+
+  fillDemoData() {
+    this.legalStructure.businessType = "Company";
+    this.legalStructure.requirements = [{ description: "Register business name", status: "Pending", deadline: "" }];
+    this.notes = "Consider hiring an accountant.";
+  }
   trackByIndex(index: number, item: any): number {
     return index;
   }

--- a/src/app/tab/new-financial/new-financial.component.html
+++ b/src/app/tab/new-financial/new-financial.component.html
@@ -6,6 +6,9 @@
   
     </div>
       <p class="video-description">{{videoDescription}}</p>
+      <div class="mt-2">
+        <button (click)="fillDemoData()" class="btn btn-secondary">Show Demo Data</button>
+      </div>
     </section>
 
     <div class="max-w-2xl mx-auto p-6 bg-white rounded-2xl shadow-lg space-y-6">

--- a/src/app/tab/new-financial/new-financial.component.ts
+++ b/src/app/tab/new-financial/new-financial.component.ts
@@ -52,7 +52,7 @@ export class NewFinancialComponent implements OnInit {
      })  
     }
     getfinnacial(){
-      this.apisService.getfinnancial().subscribe((res)=>{
+    this.apisService.getfinnancial().subscribe((res)=>{
      
        // console.log(res);
         if (res && Object.keys(res).length > 0){
@@ -63,6 +63,10 @@ export class NewFinancialComponent implements OnInit {
 }else{
   this.isSaved=true
 }
-       }) 
+       })
     }
+
+  fillDemoData() {
+    this.notes = 'Estimate startup costs and monthly expenses.';
+  }
 }

--- a/src/app/tab/new-marketing/new-marketing.component.html
+++ b/src/app/tab/new-marketing/new-marketing.component.html
@@ -5,6 +5,9 @@
         <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" ></video>
       </div>
       <p class="video-description">{{videoDescription}}</p>
+      <div class="mt-2">
+        <button (click)="fillDemoData()" class="btn btn-secondary">Show Demo Data</button>
+      </div>
     </section>
   
     <div class="business bg-white p-4 rounded-lg shadow space-y-4">

--- a/src/app/tab/new-marketing/new-marketing.component.ts
+++ b/src/app/tab/new-marketing/new-marketing.component.ts
@@ -214,7 +214,7 @@ updateProgress(){
     }
   });  
 }
-getnewmarketing() {
+  getnewmarketing() {
   this.apisService.getNewmarketing().subscribe({
     next: (res) => {
     //  console.log('Response:', res);
@@ -234,6 +234,27 @@ localStorage.setItem("marid",res.data.productFeature.id)
      // console.error('Error:', error);
     }
   });
+}
+
+fillDemoData() {
+  this.product_feature = {
+    options: [
+      'Feature one that stands out',
+      'Another unique feature',
+      'Third compelling feature'
+    ],
+    notes: 'These features address customer pain points.'
+  };
+
+  this.marketing_campaigns = [
+    {
+      goal: 'Create awareness',
+      audience: 'Young professionals',
+      format: 'Video ads',
+      channels: 'Social media',
+      notes: 'Focus on benefits'
+    }
+  ];
 }
 
 

--- a/src/app/tab/new-sales/new-sales.component.html
+++ b/src/app/tab/new-sales/new-sales.component.html
@@ -6,6 +6,9 @@
   
     </div>
       <p class="video-description">{{videoDescription}}</p>
+      <div class="mt-2">
+        <button (click)="fillDemoData()" class="btn btn-secondary">Show Demo Data</button>
+      </div>
     </section>
     <div class="p-6 max-w-4xl mx-auto">
         <h1 class="text-2xl font-bold mb-4">Sales Funnel Calculator</h1>

--- a/src/app/tab/new-sales/new-sales.component.ts
+++ b/src/app/tab/new-sales/new-sales.component.ts
@@ -196,6 +196,13 @@ validatePositive(field: string) {
         // console.error('Error updating ', error);
          // التعامل مع الخطأ مثل إظهار رسالة للمستخدم
        }
-    })
+  })
+  }
+
+  fillDemoData() {
+    this.target_revenue = 10000;
+    this.unit_price = 50;
+    this.interactions_needed = 200;
+    this.reach_to_interaction_percentage = 10;
   }
 }

--- a/src/app/tab/website/website.component.html
+++ b/src/app/tab/website/website.component.html
@@ -1,6 +1,7 @@
 <div class="web-container">
     <div class="max-w-2xl mx-auto p-6 bg-white shadow-lg rounded-xl">
         <h1 class="text-2xl font-bold mb-2">Your Business Website Details</h1>
+        <button (click)="fillDemoData()" class="btn btn-secondary mb-2">Show Demo Data</button>
       
         <div class="space-y-6">
           <div>

--- a/src/app/tab/website/website.component.ts
+++ b/src/app/tab/website/website.component.ts
@@ -177,6 +177,21 @@ services = [
       }
     });
   }
+
+  fillDemoData() {
+    this.businessName = 'Demo Bakery';
+    this.businessDescription = 'We make the best cupcakes in town.';
+    this.colourChoice = 1;
+    this.logoStyleChoice = 5;
+    this.aboutUs = 'Family-run bakery with a passion for sweets.';
+    this.socialProof = 'Over 1,000 satisfied customers.';
+    this.contactInfo = 'email@example.com\n+123456789';
+    this.services = [
+      { name: 'Cupcake orders', description: 'Fresh cupcakes baked daily.' },
+      { name: 'Custom cakes', description: 'Made to order for any event.' },
+      { name: 'Baking classes', description: 'Learn how to bake like a pro.' }
+    ];
+  }
   
 
 }


### PR DESCRIPTION
## Summary
- add `Show Demo Data` buttons across form pages
- provide helper methods to fill example values for all forms

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c19fc0f0083339a25839f5ff24a69