### PR TITLE
Fix Angular template parsing error in language selector

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -27,7 +27,7 @@
       <span *ngIf="!isLoading">SIGN OUT</span>
       <span *ngIf="isLoading">LOADING...</span>
     </button>
-      <select (change)="changeLang(($event.target as HTMLSelectElement).value)" [value]="currentLang" class="lang-select">
+      <select (change)="changeLang($any($event.target).value)" [value]="currentLang" class="lang-select">
       <option value="en">EN</option>
       <option value="ar">AR</option>
       <option value="es">ES</option>


### PR DESCRIPTION
## Summary
- fix change handler in `header.component.html` by using `$any($event.target).value`

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6af309e48333b67aa1416f8fb29b