### PR TITLE
Use environment variable for OpenAI key

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
 
+## Environment variables
+
+Create a `.env` file in the project root with the following variable:
+
+```bash
+OPENAI_API_KEY=your-openai-api-key
+```
+
+This key is used by `OpenAIService` to authenticate requests.
+
 ## Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.

--- a/src/app/services/openai.service.ts
+++ b/src/app/services/openai.service.ts
@@ -1,12 +1,14 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class OpenAIService {
   private apiUrl = 'https://api.openai.com/v1/chat/completions';
+  private apiKey = environment.OPENAI_API_KEY;
  
 
   constructor(private http: HttpClient) {}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,6 @@
+declare const process: { env: { [key: string]: string | undefined } };
+
 export const environment = {
   production: false,
-  OPENAI_API_KEY: 'your-api-key-here'
-}; 
+  OPENAI_API_KEY: process.env['OPENAI_API_KEY'] || ''
+};


### PR DESCRIPTION
## Summary
- read OpenAI API key from environment configuration
- reference the key in `OpenAIService`
- describe `.env` setup in README
- add a sample `.env` file

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb78eae348333ab1ca14043e824d5