### PR TITLE
Fix build error from process variable

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,6 @@
-declare const process: { env: { [key: string]: string | undefined } };
+declare const process: { env: { [key: string]: string | undefined } } | undefined;
 
 export const environment = {
   production: false,
-  OPENAI_API_KEY: process.env['OPENAI_API_KEY'] || ''
+  OPENAI_API_KEY: typeof process !== 'undefined' ? process.env['OPENAI_API_KEY'] ?? '' : ''
 };


### PR DESCRIPTION
## Summary
- avoid using Node `process` when deploying to the browser

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebc0954f883339a68b9befc400661