### PR TITLE
Modern landing page styling

### DIFF
--- a/src/app/landing-page/landing-page.component.css
+++ b/src/app/landing-page/landing-page.component.css
@@ -1,46 +1,46 @@
 /* landing-page.component.css */
 .landing-page-container {
-  @apply grid gap-8 max-w-7xl mx-auto my-8 px-4;
+  @apply max-w-6xl mx-auto space-y-6 px-4;
 }
 
 .plans-section {
   @apply bg-white rounded-xl shadow-md p-6;
 }
 
-.plan-header {
-  @apply text-center mb-8;
-}
-
 .logo {
-  @apply w-44 mb-6;
+  @apply w-44 mx-auto mb-6;
 }
 
-.plans-list {
-  @apply bg-gray-100 rounded-lg p-4 space-y-4;
+.tip-banner {
+  @apply bg-yellow-50 text-yellow-800 p-2 text-center rounded mb-4;
 }
 
-.plan-item {
-  @apply flex justify-between items-center p-4 bg-white rounded-md shadow-sm;
+.section-title {
+  @apply text-3xl font-bold text-gray-800;
 }
 
-.action-buttons {
-  @apply flex gap-2;
+.plan-grid {
+  @apply grid gap-6 sm:grid-cols-2 lg:grid-cols-3;
 }
 
-.edit-btn {
-  @apply bg-gray-600 text-white font-semibold px-4 py-2 rounded-md transition-colors hover:bg-gray-700;
+.plan-card {
+  @apply card flex flex-col justify-between;
+}
+
+.plan-name {
+  @apply text-lg font-semibold text-gray-800 cursor-pointer hover:text-primary transition;
+}
+
+.icon-btn {
+  @apply inline-flex items-center justify-center p-2 rounded-md bg-gray-100 text-gray-600 hover:bg-primary hover:text-white transition;
 }
 
 .delete-btn {
-  @apply bg-red-600 text-white font-semibold px-4 py-2 rounded-md transition-colors hover:bg-red-700;
+  @apply bg-gray-100 text-gray-600 hover:bg-red-600 hover:text-white;
 }
 
-.add-plan-btn {
-  @apply w-1/2 mt-6 bg-primary text-white font-semibold px-4 py-2 rounded-md transition-colors hover:bg-blue-600;
-}
-
-.clickable-plan {
-  @apply text-blue-700 font-semibold cursor-pointer px-2 rounded transition transform hover:bg-indigo-100 hover:text-blue-800 hover:scale-105 active:scale-95 focus:outline-none focus:ring-2 focus:ring-indigo-500;
+.add-card {
+  @apply border-2 border-dashed border-gray-300 rounded-lg flex flex-col items-center justify-center py-8 text-gray-500 hover:border-primary hover:text-primary transition;
 }
 
 @media (max-width: 768px) {
@@ -49,8 +49,5 @@
   }
   .section-title {
     @apply text-xl;
-  }
-  .disabled-btn {
-    @apply opacity-60 cursor-not-allowed;
   }
 }

--- a/src/app/landing-page/landing-page.component.html
+++ b/src/app/landing-page/landing-page.component.html
@@ -8,32 +8,36 @@
 
 <div class="landing-page-container py-6">
   <div class="plans-section">
-    <div class="mb-3 text-center bg-yellow-50 text-yellow-800 p-2 rounded" role="alert">
-      📝 <strong>Tip:</strong> Add a new business plan, then click on the plan name to open its workspace.
+    <div class="tip-banner" role="alert">
+      <span class="font-semibold">📝 Tip:</span> Add a new business plan, then click on the plan name to open its workspace.
     </div>
 
-    <div class="plan-header">
-      <h1 class="section-title">📌 Business Plans</h1>
-    </div>
+    <h1 class="section-title text-center mb-6">Business Plans</h1>
 
-    <div class="plan-content">
-      <div class="plans-list">
-        <ul>
-          <li *ngFor="let plan of businessPlans; let i = index" class="plan-item">
-            <span class="clickable-plan" (click)="saveBussinesId(plan.id)">
-              {{ plan.name }}
-            </span>
-            <div class="action-buttons">
-              <button (click)="editPlan(i)" class="edit-btn">✏ Edit</button>
-              <button (click)="deletePlan(plan.id)" class="delete-btn">🗑 Delete</button>
-            </div>
-          </li>
-        </ul>
-      </div>
-
-      <div class="text-center">
-        <button (click)="addBusinessPlan()" class="add-plan-btn">➕ Add New Plan</button>
-      </div>
+    <div class="plan-grid">
+      <ng-container *ngFor="let plan of businessPlans; let i = index">
+        <div class="plan-card">
+          <span class="plan-name" (click)="saveBussinesId(plan.id)">{{ plan.name }}</span>
+          <div class="flex justify-end gap-2 mt-4">
+            <button (click)="editPlan(i)" class="icon-btn" aria-label="Edit">
+              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536M4.5 19.5L5.75 14.75 14.768 5.732a2.25 2.25 0 013.182 3.182L8.932 17.932 4.5 19.5z" />
+              </svg>
+            </button>
+            <button (click)="deletePlan(plan.id)" class="icon-btn delete-btn" aria-label="Delete">
+              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3m5 0H6" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </ng-container>
+      <button (click)="addBusinessPlan()" class="add-card">
+        <svg class="w-6 h-6 mb-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+        </svg>
+        <span class="font-medium">Add New Plan</span>
+      </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- revamp landing page layout
- rebuild plan list as grid of cards using Tailwind
- include minimal heroicon-style inline SVG icons

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcf6099308333ada5b2f3af1a6d1e