### PR TITLE
Enhance landing page and plan modals

### DIFF
--- a/src/app/add-plans/add-plans.component.css
+++ b/src/app/add-plans/add-plans.component.css
@@ -1,18 +1,11 @@
-/* ::ng-deep .mat-dialog-container {
-    padding: 0;
-    overflow: auto;
-    max-height: 90vh;
-    border-radius: 16px;
-  }
-   */
-   ::ng-deep .mat-dialog-container {
-    padding: 0;
-    overflow: auto;
-    max-height: 90vh;
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-radius: 16px;
-  }
-  
+/* add-plans.component.css */
+:host ::ng-deep .mat-dialog-container {
+  padding: 0;
+  overflow: auto;
+  max-height: 90vh;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 16px;
+}

--- a/src/app/add-plans/add-plans.component.html
+++ b/src/app/add-plans/add-plans.component.html
@@ -1,5 +1,5 @@
 <!-- حاوية الديالوج -->
-<div class="p-4 sm:p-6 bg-gray-50 rounded-xl shadow-lg w-full max-w-lg mx-auto overflow-auto max-h-[80vh]">
+<div class="p-6 bg-gray-50 rounded-xl shadow-lg w-full max-w-lg mx-auto overflow-auto max-h-[80vh]" (keydown.escape)="dialogRef.close()">
   <h1 class="text-2xl sm:text-3xl font-bold mb-6 text-center text-blue-700">
     Business Onboarding Questionnaire
   </h1>
@@ -7,9 +7,10 @@
   <!-- Full Name Section -->
   <div class="mb-6">
     <label class="block text-base sm:text-lg font-semibold mb-2">Plan Name</label>
-    <input type="text" [(ngModel)]="firstName" 
-           placeholder="Enter Bussines Plan Name " 
+    <input type="text" [(ngModel)]="firstName" #name="ngModel" required autofocus
+           placeholder="Enter Business Plan Name"
            class="w-full p-3 border border-gray-300 rounded-md focus:border-blue-500 focus:outline-none">
+    <p *ngIf="name.invalid && name.touched" class="text-red-600 text-sm mt-1">Plan name is required.</p>
   </div>
 
   <!-- Migrant/Refugee Question -->
@@ -98,15 +99,15 @@
 
   <!-- Save / Update Buttons -->
   <div class="flex justify-center gap-4 mt-8 flex-wrap">
-    <button *ngIf="!isSaved" 
-            (click)="submitForm()" 
+    <button *ngIf="!isSaved"
+            (click)="submitForm()"
             class="px-6 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition w-full sm:w-auto">
-      <i class="fas fa-save"></i> Save
+      Save Plan
     </button>
-    <button *ngIf="isSaved" 
-            (click)="updateForm()" 
+    <button *ngIf="isSaved"
+            (click)="updateForm()"
             class="px-6 py-3 bg-green-600 text-white rounded-md hover:bg-green-700 transition w-full sm:w-auto">
-      <i class="fas fa-save"></i> Update
+      Update Plan
     </button>
   </div>
 </div>

--- a/src/app/add-plans/add-plans.component.ts
+++ b/src/app/add-plans/add-plans.component.ts
@@ -69,6 +69,10 @@ toggleBusinessOwnership(status: boolean): void {
   if (!status) this.businessDescription = '';
 }
   submitForm(): void {
+    if (!this.firstName.trim()) {
+      this.snackBar.open('Plan name is required', 'Close', { duration: 2000 });
+      return;
+    }
     const formdata = {
       name: this.firstName,
       products_services: [this.businessDescription || ''],
@@ -89,6 +93,10 @@ toggleBusinessOwnership(status: boolean): void {
     });
   }
   updateForm(): void {
+    if (!this.firstName.trim()) {
+      this.snackBar.open('Plan name is required', 'Close', { duration: 2000 });
+      return;
+    }
     const formdata = {
       name: this.firstName,
       products_services: [this.businessDescription || ''],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -40,6 +40,7 @@ import { NewMarketingComponent } from './tab/new-marketing/new-marketing.compone
 import { NewSalesComponent } from './tab/new-sales/new-sales.component';
 import { NewBusinessSetupComponent } from './tab/new-business-setup/new-business-setup.component';
 import { AddPlansComponent } from './add-plans/add-plans.component';
+import { ConfirmDeleteComponent } from './confirm-delete/confirm-delete.component';
 import { NewFinancialComponent } from './tab/new-financial/new-financial.component';
 import { WebsiteComponent } from './tab/website/website.component';
 import { FooterComponent } from './footer/footer.component';
@@ -73,6 +74,7 @@ import { FooterComponent } from './footer/footer.component';
     NewSalesComponent,
     NewBusinessSetupComponent,
     AddPlansComponent,
+    ConfirmDeleteComponent,
     NewFinancialComponent,
     WebsiteComponent,
     FooterComponent

--- a/src/app/confirm-delete/confirm-delete.component.css
+++ b/src/app/confirm-delete/confirm-delete.component.css
@@ -1,0 +1,4 @@
+/* confirm-delete.component.css */
+:host {
+  @apply block;
+}

--- a/src/app/confirm-delete/confirm-delete.component.html
+++ b/src/app/confirm-delete/confirm-delete.component.html
@@ -1,0 +1,13 @@
+<div class="p-6 bg-white rounded-xl shadow-lg w-full max-w-sm mx-auto">
+  <p class="text-center text-gray-700 mb-6">
+    Are you sure you want to delete this plan? This action cannot be undone.
+  </p>
+  <div class="flex justify-end gap-4">
+    <button (click)="confirm()" class="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700">
+      Yes, Delete
+    </button>
+    <button (click)="cancel()" class="px-4 py-2 bg-gray-200 rounded-md hover:bg-gray-300">
+      Cancel
+    </button>
+  </div>
+</div>

--- a/src/app/confirm-delete/confirm-delete.component.ts
+++ b/src/app/confirm-delete/confirm-delete.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-confirm-delete',
+  templateUrl: './confirm-delete.component.html',
+  styleUrls: ['./confirm-delete.component.css']
+})
+export class ConfirmDeleteComponent {
+  constructor(private dialogRef: MatDialogRef<ConfirmDeleteComponent>) {}
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+}

--- a/src/app/landing-page/landing-page.component.css
+++ b/src/app/landing-page/landing-page.component.css
@@ -15,6 +15,10 @@
   @apply bg-yellow-50 text-yellow-800 p-2 text-center rounded mb-4;
 }
 
+.motivation-banner {
+  @apply bg-blue-50 text-blue-700 mx-4 p-3 rounded text-center font-semibold;
+}
+
 .section-title {
   @apply text-3xl font-bold text-gray-800;
 }

--- a/src/app/landing-page/landing-page.component.html
+++ b/src/app/landing-page/landing-page.component.html
@@ -2,29 +2,29 @@
 <div class="flex justify-center py-4">
   <img src="assets/images/VN Logo Secondary Web.png" alt="Value Nation Logo" class="logo">
 </div>
-<div class="bg-blue-50 text-blue-700 mx-4 p-3 rounded text-center" role="alert">
-  🚀 <strong>Turn Ideas into Success:</strong> With our guidance, create winning marketing strategies and build the thriving business you've always envisioned!
+<div class="motivation-banner" role="alert">
+  🚀 <strong>Turn Your Ideas into Reality:</strong> Let us help you craft marketing strategies and build a business that truly grows!
 </div>
 
 <div class="landing-page-container py-6">
   <div class="plans-section">
     <div class="tip-banner" role="alert">
-      <span class="font-semibold">📝 Tip:</span> Add a new business plan, then click on the plan name to open its workspace.
+      <span class="font-semibold">📝 Tip:</span> Start by creating a business plan. Click the plan card to enter its workspace and begin building your vision.
     </div>
 
     <h1 class="section-title text-center mb-6">Business Plans</h1>
 
     <div class="plan-grid">
       <ng-container *ngFor="let plan of businessPlans; let i = index">
-        <div class="plan-card">
-          <span class="plan-name" (click)="saveBussinesId(plan.id)">{{ plan.name }}</span>
+        <div class="plan-card cursor-pointer" (click)="openPlan(plan.id)" role="button" tabindex="0">
+          <span class="plan-name">{{ plan.name }}</span>
           <div class="flex justify-end gap-2 mt-4">
-            <button (click)="editPlan(i)" class="icon-btn" aria-label="Edit">
+            <button (click)="$event.stopPropagation(); editPlan(i)" class="icon-btn" aria-label="Edit">
               <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536M4.5 19.5L5.75 14.75 14.768 5.732a2.25 2.25 0 013.182 3.182L8.932 17.932 4.5 19.5z" />
               </svg>
             </button>
-            <button (click)="deletePlan(plan.id)" class="icon-btn delete-btn" aria-label="Delete">
+            <button (click)="$event.stopPropagation(); deletePlan(plan.id)" class="icon-btn delete-btn" aria-label="Delete">
               <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3m5 0H6" />
               </svg>

--- a/src/app/landing-page/landing-page.component.ts
+++ b/src/app/landing-page/landing-page.component.ts
@@ -5,6 +5,7 @@ import { AddBusinessComponent } from '../add-business/add-business.component';
 import { ApisService } from '../services/apis.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AddPlansComponent } from '../add-plans/add-plans.component';
+import { ConfirmDeleteComponent } from '../confirm-delete/confirm-delete.component';
 @Component({
   selector: 'app-landing-page',
   templateUrl: './landing-page.component.html',
@@ -70,13 +71,20 @@ toggleBusinessOwnership(status: boolean): void {
     });
   }
 
+  openPlan(id: any) {
+    this.saveBussinesId(id);
+  }
+
   deletePlan(id: number) {
-    //this.businessPlans.splice(index, 1);
-    return this.serv.deletebusinnes(id).subscribe((res)=>{
-      this.getbusinnis()
-      this.snackBar.open('Plan deleted!', 'Close', { duration: 2000 });
-    })
-   
+    const dialogRef = this.dialog.open(ConfirmDeleteComponent);
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.serv.deletebusinnes(id).subscribe(() => {
+          this.getbusinnis();
+          this.snackBar.open('Plan deleted!', 'Close', { duration: 2000 });
+        });
+      }
+    });
   }
 
   editPlan(index: number) {


### PR DESCRIPTION
## Summary
- add confirmation dialog for plan deletion
- make plan cards fully clickable and update tips
- improve motivational banner style
- refine Add/Edit Plan modal with validation and ESC close

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684fda8f0d0083338f4cf5385bf929e5