### PR TITLE
Fix AddPlans dialogRef visibility

### DIFF
--- a/src/app/add-plans/add-plans.component.ts
+++ b/src/app/add-plans/add-plans.component.ts
@@ -33,7 +33,7 @@ constructor(
   private snackBar: MatSnackBar,
   private serv: ApisService,
   @Inject(MAT_DIALOG_DATA) public data: { bussinesPlan: any },
-  private dialogRef: MatDialogRef<AddPlansComponent>
+  public dialogRef: MatDialogRef<AddPlansComponent>
 ) {
   if (data && data.bussinesPlan) {
     this.isSaved = true;


### PR DESCRIPTION
## Summary
- make the dialogRef of `AddPlansComponent` public so it can be referenced from the template

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdd4c4e748333acbfab4cedc0ad74