### PR TITLE
Improve landing page and add reusable modal

### DIFF
--- a/src/app/add-plans/add-plans.component.css
+++ b/src/app/add-plans/add-plans.component.css
@@ -1,11 +1,4 @@
 /* add-plans.component.css */
-:host ::ng-deep .mat-dialog-container {
-  padding: 0;
-  overflow: auto;
-  max-height: 90vh;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 16px;
+:host {
+  @apply block;
 }

--- a/src/app/add-plans/add-plans.component.html
+++ b/src/app/add-plans/add-plans.component.html
@@ -1,5 +1,5 @@
-<!-- حاوية الديالوج -->
-<div class="p-6 bg-gray-50 rounded-xl shadow-lg w-full max-w-lg mx-auto overflow-auto max-h-[80vh]" (keydown.escape)="dialogRef.close()">
+<!-- Plan form content -->
+<div>
   <h1 class="text-2xl sm:text-3xl font-bold mb-6 text-center text-blue-700">
     Business Onboarding Questionnaire
   </h1>

--- a/src/app/add-plans/add-plans.component.ts
+++ b/src/app/add-plans/add-plans.component.ts
@@ -1,8 +1,6 @@
-import { Component, Inject, OnInit } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ApisService } from '../services/apis.service';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-add-plans',
@@ -10,6 +8,10 @@ import { Router } from '@angular/router';
   styleUrls: ['./add-plans.component.css']
 })
 export class AddPlansComponent implements OnInit{
+
+  @Input() plan: any | null = null;
+  @Output() saved = new EventEmitter<any>();
+  @Output() close = new EventEmitter<void>();
 
   firstName: string = '';
 isMigrant: boolean = false;
@@ -29,35 +31,22 @@ isSaved : boolean =false
 
 
 constructor(
-  public dialog: MatDialog,
   private snackBar: MatSnackBar,
-  private serv: ApisService,
-  @Inject(MAT_DIALOG_DATA) public data: { bussinesPlan: any },
-  public dialogRef: MatDialogRef<AddPlansComponent>
-) {
-  if (data && data.bussinesPlan) {
+  private serv: ApisService
+) {}
+
+ngOnInit(): void {
+  if (this.plan) {
     this.isSaved = true;
-    const plan = data.bussinesPlan;  // 👈 مباشرة بدون .data[]
-console.log(plan)
+    const plan = this.plan;
     this.firstName = plan.name || '';
-    //this.isMigrant = plan.is_migrant === 1;
     this.yearsInCountry = plan.years_here || 0;
     this.selectedEnglishLevel = plan.english_level ? plan.english_level[0] : '';
-   // this.hasBusiness = plan.is_business_old === 1;
     this.businessDescription = plan.products_services ? plan.products_services[0] : '';
     this.aboutme = plan.about_me ? plan.about_me[0] : '';
     this.isMigrant = plan.is_migrant === 1 ? true : false;
     this.hasBusiness = plan.is_business_old === 1 ? true : false;
   }
-}
-ngOnInit(): void {
-  // const id = this.route.snapshot.paramMap.get('id');
-  // if (id) {
-  //   localStorage.setItem("businnes-id", id);
-    
-  // }
-  //this.getbusinesform()
- 
 }
 toggleMigrantStatus(status: boolean): void {
   this.isMigrant = status;
@@ -82,14 +71,12 @@ toggleBusinessOwnership(status: boolean): void {
       english_level: [this.selectedEnglishLevel],
       is_business_old: this.hasBusiness
     };
-  
+
     this.serv.saveNewbusines(formdata).subscribe((res) => {
-      localStorage.setItem("bid",res.data.id)
-     // this.getbusinesform() 
-  
+      localStorage.setItem('bid', res.data.id);
       this.snackBar.open('Business saved successfully!', 'Close', { duration: 2000 });
-      this.dialogRef.close(res.data); 
-      
+      this.saved.emit(res.data);
+      this.close.emit();
     });
   }
   updateForm(): void {
@@ -108,11 +95,9 @@ toggleBusinessOwnership(status: boolean): void {
     };
   
     this.serv.updatenewbusiness(formdata).subscribe((res) => {
-      //this.getbusinesform()
-   // console.log(  res) 
       this.snackBar.open('Business updated successfully!', 'Close', { duration: 2000 });
-      this.dialogRef.close(res.data); 
-      
+      this.saved.emit(res.data);
+      this.close.emit();
     });
   }
   getbusinesform() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -44,6 +44,7 @@ import { ConfirmDeleteComponent } from './confirm-delete/confirm-delete.componen
 import { NewFinancialComponent } from './tab/new-financial/new-financial.component';
 import { WebsiteComponent } from './tab/website/website.component';
 import { FooterComponent } from './footer/footer.component';
+import { ModalComponent } from './modal/modal.component';
 
 @NgModule({
   declarations: [
@@ -77,7 +78,8 @@ import { FooterComponent } from './footer/footer.component';
     ConfirmDeleteComponent,
     NewFinancialComponent,
     WebsiteComponent,
-    FooterComponent
+    FooterComponent,
+    ModalComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,4 +1,4 @@
-<nav class="bg-primary text-white py-4 shadow">
+<nav class="bg-blue-600 text-white py-4 shadow">
   <div class="max-w-7xl mx-auto px-4 flex items-center justify-between">
     <div class="font-bold uppercase">Value Nation Business Startup Tool</div>
     <div class="flex items-center gap-4">

--- a/src/app/landing-page/landing-page.component.css
+++ b/src/app/landing-page/landing-page.component.css
@@ -16,7 +16,7 @@
 }
 
 .motivation-banner {
-  @apply bg-blue-50 text-blue-700 mx-4 p-3 rounded text-center font-semibold;
+  @apply bg-blue-100 text-blue-700 mx-4 p-3 rounded text-center font-semibold;
 }
 
 .section-title {

--- a/src/app/landing-page/landing-page.component.html
+++ b/src/app/landing-page/landing-page.component.html
@@ -41,3 +41,8 @@
     </div>
   </div>
 </div>
+
+<app-modal [title]="editingPlan ? 'Edit Plan' : 'Add Plan'"
+           [show]="showPlanModal" (onClose)="closePlanModal()">
+  <app-add-plans [plan]="editingPlan" (saved)="onPlanSaved()" (close)="closePlanModal()"></app-add-plans>
+</app-modal>

--- a/src/app/landing-page/landing-page.component.ts
+++ b/src/app/landing-page/landing-page.component.ts
@@ -13,6 +13,8 @@ import { ConfirmDeleteComponent } from '../confirm-delete/confirm-delete.compone
 })
 export class LandingPageComponent implements OnInit {
   businessPlans: any[] = [];
+  showPlanModal = false;
+  editingPlan: any | null = null;
  
 
   constructor(public dialog: MatDialog, private snackBar: MatSnackBar,private serv:ApisService,private router: Router
@@ -27,48 +29,14 @@ ngOnInit(): void {
   this.getbusinnis()
  
 }
-firstName: string = '';
-isMigrant: boolean = false;
-yearsInCountry!: number ;
-englishLevels: string[] = [
-  'No English',
-  'Low level',
-  'Intermediate',
-  'Great',
-  'Academic'
-];
-  selectedEnglishLevel!: string;
-hasBusiness: boolean = false;
-businessDescription: string='';
-aboutme:string=""
-isSaved : boolean =false
- 
-toggleMigrantStatus(status: boolean): void {
-  this.isMigrant = status;
-  if (!status) this.yearsInCountry = 0;
-}
-
-toggleBusinessOwnership(status: boolean): void {
-  this.hasBusiness = status;
-  if (!status) this.businessDescription = '';
-}
 
 
 
 
 
   addBusinessPlan() {
-    const dialogRef = this.dialog.open(AddPlansComponent);
-
-    dialogRef.afterClosed().subscribe(result => {
-      this.getbusinnis()
-
-      if (result) {
-        this.getbusinnis()
-      //  this.businessPlans.push(result);
-        this.snackBar.open('Plan added successfully!', 'Close', { duration: 2000 });
-      }
-    });
+    this.editingPlan = null;
+    this.showPlanModal = true;
   }
 
   openPlan(id: any) {
@@ -88,18 +56,19 @@ toggleBusinessOwnership(status: boolean): void {
   }
 
   editPlan(index: number) {
-    const dialogRef = this.dialog.open(AddPlansComponent, {
-      data:{bussinesPlan: this.businessPlans[index]} 
-    });
+    this.editingPlan = this.businessPlans[index];
+    this.showPlanModal = true;
+  }
 
-    dialogRef.afterClosed().subscribe(result => {
-      
-      if (result) {
-        this.getbusinnis()
-       // this.businessPlans[index] = result;getbusinnes()
-        this.snackBar.open('Plan updated successfully!', 'Close', { duration: 2000 });
-      } 
-    });
+  closePlanModal() {
+    this.showPlanModal = false;
+    this.editingPlan = null;
+  }
+
+  onPlanSaved() {
+    this.getbusinnis();
+    this.snackBar.open('Plan saved successfully!', 'Close', { duration: 2000 });
+    this.closePlanModal();
   }
   getbusinnis(){
 return this.serv.getbussinesform().subscribe((res)=>{

--- a/src/app/modal/modal.component.css
+++ b/src/app/modal/modal.component.css
@@ -1,0 +1,3 @@
+:host {
+  @apply block;
+}

--- a/src/app/modal/modal.component.html
+++ b/src/app/modal/modal.component.html
@@ -1,0 +1,7 @@
+<div *ngIf="show" class="fixed inset-0 z-50 flex items-center justify-center" @overlay (click)="closeOnOverlay ? close() : null">
+  <div class="bg-white rounded-xl shadow-xl w-full max-w-xl mx-4 p-6 relative" @fadeScale (click)="$event.stopPropagation()">
+    <button class="absolute top-2 right-2 text-gray-500 hover:text-gray-700" (click)="close()" aria-label="Close">&times;</button>
+    <h2 *ngIf="title" class="text-xl font-semibold mb-4">{{ title }}</h2>
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/src/app/modal/modal.component.ts
+++ b/src/app/modal/modal.component.ts
@@ -1,0 +1,46 @@
+import { Component, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { trigger, style, animate, transition } from '@angular/animations';
+
+@Component({
+  selector: 'app-modal',
+  templateUrl: './modal.component.html',
+  styleUrls: ['./modal.component.css'],
+  animations: [
+    trigger('overlay', [
+      transition(':enter', [
+        style({ opacity: 0 }),
+        animate('150ms ease-out', style({ opacity: 1 }))
+      ]),
+      transition(':leave', [
+        animate('150ms ease-in', style({ opacity: 0 }))
+      ])
+    ]),
+    trigger('fadeScale', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'scale(0.95)' }),
+        animate('150ms ease-out', style({ opacity: 1, transform: 'scale(1)' }))
+      ]),
+      transition(':leave', [
+        animate('150ms ease-in', style({ opacity: 0, transform: 'scale(0.95)' }))
+      ])
+    ])
+  ]
+})
+export class ModalComponent {
+  @Input() title = '';
+  @Input() show = false;
+  @Input() closeOnOverlay = true;
+
+  @Output() onClose = new EventEmitter<void>();
+
+  close() {
+    this.onClose.emit();
+  }
+
+  @HostListener('document:keydown.escape')
+  handleEscape() {
+    if (this.show) {
+      this.close();
+    }
+  }
+}

--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -3,5 +3,9 @@
 }
 
 .nav-link-active {
-  @apply text-primary font-medium;
+  @apply text-primary font-semibold;
+}
+
+.nav-links a {
+  @apply md:mx-1;
 }

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -7,12 +7,13 @@
     <button class="menu-toggle md:hidden text-gray-600" (click)="toggleNavbar()" aria-label="Toggle navigation">
       <i class="fas fa-bars"></i>
     </button>
-    <div class="nav-links w-full md:flex md:items-center md:space-x-4" [ngClass]="{ 'hidden': isNavbarCollapsed, 'block': !isNavbarCollapsed, 'mt-2': !isNavbarCollapsed }">
+    <div class="nav-links w-full md:flex md:items-center md:space-x-6" [ngClass]="{ 'hidden': isNavbarCollapsed, 'block': !isNavbarCollapsed, 'mt-2': !isNavbarCollapsed }">
       <a *ngFor="let link of navLinks"
          routerLink="{{link.path}}"
          routerLinkActive="nav-link-active"
          [routerLinkActiveOptions]="{ exact: true }"
-         class="block px-3 py-2 text-sm text-gray-700 hover:text-primary transition-colors md:inline-block">
+         class="block px-3 py-2 text-sm text-gray-700 hover:text-primary transition-colors md:inline-block flex items-center gap-1">
+        <i class="fas fa-circle text-[6px] md:text-xs"></i>
         {{ link.label | translate }}
       </a>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -25,4 +25,12 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
   .card {
     @apply bg-white rounded-xl shadow-md p-6;
   }
+
+  .video-section {
+    @apply bg-white rounded-lg shadow p-4 mt-6 max-w-3xl mx-auto text-center;
+  }
+
+  .video-section video {
+    @apply w-full rounded-md border border-gray-200;
+  }
 }


### PR DESCRIPTION
## Summary
- build global `app-modal` component with fade/scale transitions
- refactor AddPlans form to emit events and work inside new modal
- use modal for adding/editing plans on landing page
- tweak navbar spacing and header color
- apply consistent video section styling

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe01e38948333b6e31f9bf597549e