### PR TITLE
Fix modal scroll, nav tabs, and language change

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -119,8 +119,10 @@ export class HeaderComponent implements OnInit {
      // this.getAllData.getAllDataForPDF().subscribe((res)=>{
      // console.log(res)
      // })
-    
-   }
+    this.translation.langChange$.subscribe(lang => {
+      this.currentLang = lang;
+    });
+  }
 
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent) {
@@ -156,7 +158,6 @@ export class HeaderComponent implements OnInit {
 
   changeLang(lang: string) {
     this.translation.loadLanguage(lang as LangCode);
-    this.currentLang = this.translation.getCurrentLang();
   }
 
 

--- a/src/app/modal/modal.component.html
+++ b/src/app/modal/modal.component.html
@@ -1,5 +1,5 @@
-<div *ngIf="show" class="fixed inset-0 z-50 flex items-center justify-center" @overlay (click)="closeOnOverlay ? close() : null">
-  <div class="bg-white rounded-xl shadow-xl w-full max-w-xl mx-4 p-6 relative" @fadeScale (click)="$event.stopPropagation()">
+<div *ngIf="show" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" @overlay (click)="closeOnOverlay ? close() : null">
+  <div class="bg-white rounded-xl shadow-xl border w-full max-w-xl mx-4 p-6 max-h-[90vh] overflow-y-auto relative" @fadeScale (click)="$event.stopPropagation()">
     <button class="absolute top-2 right-2 text-gray-500 hover:text-gray-700" (click)="close()" aria-label="Close">&times;</button>
     <h2 *ngIf="title" class="text-xl font-semibold mb-4">{{ title }}</h2>
     <ng-content></ng-content>

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -7,13 +7,12 @@
     <button class="menu-toggle md:hidden text-gray-600" (click)="toggleNavbar()" aria-label="Toggle navigation">
       <i class="fas fa-bars"></i>
     </button>
-    <div class="nav-links w-full md:flex md:items-center md:space-x-6" [ngClass]="{ 'hidden': isNavbarCollapsed, 'block': !isNavbarCollapsed, 'mt-2': !isNavbarCollapsed }">
+    <div class="nav-links w-full md:flex md:items-center md:space-x-6 overflow-x-auto whitespace-nowrap" [ngClass]="{ 'hidden': isNavbarCollapsed, 'block': !isNavbarCollapsed, 'mt-2': !isNavbarCollapsed }">
       <a *ngFor="let link of navLinks"
          routerLink="{{link.path}}"
          routerLinkActive="nav-link-active"
          [routerLinkActiveOptions]="{ exact: true }"
-         class="block px-3 py-2 text-sm text-gray-700 hover:text-primary transition-colors md:inline-block flex items-center gap-1">
-        <i class="fas fa-circle text-[6px] md:text-xs"></i>
+         class="px-4 py-2 text-sm text-gray-700 hover:text-primary transition-colors inline-flex w-max whitespace-nowrap">
         {{ link.label | translate }}
       </a>
     </div>

--- a/src/app/services/translation.service.ts
+++ b/src/app/services/translation.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Observable, of, BehaviorSubject } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 export type LangCode = 'en' | 'ar' | 'es' | 'de' | 'fr' | 'zh' | 'hi' | 'pt' | 'ru' | 'bn';
@@ -9,6 +9,8 @@ export type LangCode = 'en' | 'ar' | 'es' | 'de' | 'fr' | 'zh' | 'hi' | 'pt' | '
 export class TranslationService {
   private currentLang: LangCode = 'en';
   private translations: Record<string, string> = {};
+  private langChangeSubject = new BehaviorSubject<LangCode>(this.currentLang);
+  langChange$ = this.langChangeSubject.asObservable();
 
   constructor(private http: HttpClient) {
     this.loadLanguage(this.currentLang);
@@ -21,6 +23,8 @@ export class TranslationService {
       .subscribe(data => {
         this.currentLang = lang;
         this.translations = data || {};
+        this.langChangeSubject.next(lang);
+        this.updateDocumentDirection();
       });
   }
 
@@ -30,5 +34,10 @@ export class TranslationService {
 
   translate(key: string): string {
     return this.translations[key] || key;
+  }
+
+  private updateDocumentDirection() {
+    const rtlLangs: LangCode[] = ['ar'];
+    document.documentElement.dir = rtlLangs.includes(this.currentLang) ? 'rtl' : 'ltr';
   }
 }


### PR DESCRIPTION
## Summary
- make onboarding modal scrollable and add overlay
- tidy nav tab layout and remove dot icons
- add language change observable and RTL update
- update header to watch language change

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe499749c83339f330a2827c8353e