### PR TITLE
Improve navbar and translation

### DIFF
--- a/src/app/landing-page/landing-page.component.html
+++ b/src/app/landing-page/landing-page.component.html
@@ -1,6 +1,8 @@
 <!-- landing-page.component.html -->
 <div class="flex justify-center py-4">
-  <img src="assets/images/VN Logo Secondary Web.png" alt="Value Nation Logo" class="logo">
+  <a routerLink="/landing-page" role="link" aria-label="Home" class="cursor-pointer">
+    <img src="assets/images/VN Logo Secondary Web.png" alt="Value Nation Logo" class="logo">
+  </a>
 </div>
 <div class="motivation-banner" role="alert">
   {{ 'landingPageMotivation' | translate }}

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,8 +1,7 @@
 <nav class="bg-white shadow-sm">
   <div class="max-w-7xl mx-auto px-4 flex items-center justify-between py-3">
-    <a routerLink="/landing-page" class="text-primary font-semibold flex items-center space-x-2">
-      <i class="fas fa-desktop"></i>
-      <span>Landing Page</span>
+    <a routerLink="/landing-page" role="link" aria-label="Home" class="text-primary font-semibold flex items-center cursor-pointer">
+      <i class="fas fa-desktop text-xl"></i>
     </a>
     <button class="menu-toggle md:hidden text-gray-600" (click)="toggleNavbar()" aria-label="Toggle navigation">
       <i class="fas fa-bars"></i>

--- a/src/app/tab/bussiness-setup/bussiness-setup.component.html
+++ b/src/app/tab/bussiness-setup/bussiness-setup.component.html
@@ -1,6 +1,6 @@
 <div class="business-setup-container">
   <section class="video-section">
-    <h2><i class="fas fa-video"></i> Introduction Video</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
     <div class="vedio">
       <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" autoplay></video>
 

--- a/src/app/tab/financial-planing/financial-planing.component.html
+++ b/src/app/tab/financial-planing/financial-planing.component.html
@@ -1,6 +1,6 @@
 <div class="financial-planning-container">
   <section class="video-section">
-    <h2><i class="fas fa-video"></i> Introduction Video</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
     <div class="vedio">
       <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" autoplay></video>
 

--- a/src/app/tab/launch-prepration/launch-prepration.component.html
+++ b/src/app/tab/launch-prepration/launch-prepration.component.html
@@ -1,6 +1,6 @@
 <div class="launch-preparation-container">
   <section class="video-section">
-    <h2><i class="fas fa-video"></i> Introduction Video</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
     <div class="vedio">
       <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" autoplay></video>
 

--- a/src/app/tab/market-research/market-research.component.html
+++ b/src/app/tab/market-research/market-research.component.html
@@ -1,6 +1,6 @@
 <div class="market-research-container">
   <section class="video-section">
-    <h2><i class="fas fa-video"></i> {{ 'introductionVideo' | translate }}</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
     <div class="vedio">
       <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" ></video>
 

--- a/src/app/tab/marketing/marketing.component.html
+++ b/src/app/tab/marketing/marketing.component.html
@@ -1,6 +1,6 @@
 <div class="marketing-container">
   <section class="video-section">
-    <h2><i class="fas fa-video"></i> Introduction Video</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
     <div class="vedio">
       <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" autoplay></video>
 
@@ -9,7 +9,7 @@
   </section>
   <!-- Target Market Section -->
   <section class="form-section">
-    <h2><i class="fas fa-bullseye"></i> Target Market Definition</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-bullseye"></i><span>{{ 'targetMarketDefinition' | translate }}</span></h2>
     <p class="section-description">Clearly define your target market and value proposition.</p>
 
     <div class="form-group">
@@ -48,7 +48,7 @@
 
   <!-- Marketing Channels Section -->
   <section class="form-section">
-    <h2><i class="fas fa-broadcast-tower"></i> Marketing Channels</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-broadcast-tower"></i><span>{{ 'marketingChannels' | translate }}</span></h2>
     <p class="section-description">Define your marketing channels and strategies.</p>
 
     <div class="channels-list">
@@ -106,7 +106,7 @@
 
   <!-- Content Strategy Section -->
   <section class="form-section">
-    <h2><i class="fas fa-pencil-alt"></i> Content Strategy</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-pencil-alt"></i><span>{{ 'contentStrategy' | translate }}</span></h2>
     <p class="section-description">Plan your content creation and distribution strategy.</p>
 
     <div class="content-list">
@@ -164,7 +164,7 @@
 
   <!-- Brand Identity Section -->
   <section class="form-section">
-    <h2><i class="fas fa-fingerprint"></i> Brand Identity</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-fingerprint"></i><span>{{ 'brandIdentity' | translate }}</span></h2>
     <p class="section-description">Define your brand's core identity and values.</p>
 
     <div class="brand-values">

--- a/src/app/tab/mvp-development/mvp-development.component.html
+++ b/src/app/tab/mvp-development/mvp-development.component.html
@@ -1,6 +1,6 @@
 <div class="mvp-container">
   <section class="video-section">
-    <h2><i class="fas fa-video"></i> Introduction Video</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
     <div class="vedio">
       <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" autoplay></video>
 

--- a/src/app/tab/mvp/mvp.component.html
+++ b/src/app/tab/mvp/mvp.component.html
@@ -1,6 +1,6 @@
 <div class="mvp-container">
     <section class="video-section">
-      <h2><i class="fas fa-video"></i> {{ 'introductionVideo' | translate }}</h2>
+      <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
       <div class="vedio">
         <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" ></video>
   

--- a/src/app/tab/new-business-setup/new-business-setup.component.html
+++ b/src/app/tab/new-business-setup/new-business-setup.component.html
@@ -1,6 +1,6 @@
 <div class="business-setup-container">
     <section class="video-section">
-      <h2><i class="fas fa-video"></i> {{ 'introductionVideo' | translate }}</h2>
+      <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
       <div class="vedio">
         <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" ></video>
   

--- a/src/app/tab/new-financial/new-financial.component.html
+++ b/src/app/tab/new-financial/new-financial.component.html
@@ -51,13 +51,15 @@
         <!-- زر حفظ -->
 
         <div class="save-section d-flex justify-content-center mt-3">
-          <button class="btn btn-primary save-progress" *ngIf="isSaved"  (click)="saveProgress()">
-            <i class="fas fa-save"></i> {{ 'saveProgress' | translate }}
+          <button class="btn btn-primary save-progress inline-flex items-center gap-2" *ngIf="isSaved"  (click)="saveProgress()">
+            <i class="fas fa-save"></i>
+            <span>{{ 'saveProgress' | translate }}</span>
           </button>
         </div>
-        <div class="update-section d-flex justify-content-around mt-3">
-          <button class="btn btn-primary save-progress" *ngIf="!isSaved" (click)="updateProgress()">
-            <i class="fas fa-save"></i> {{ 'updateProgress' | translate }}
+        <div class="update-section flex justify-around mt-3">
+          <button class="btn btn-primary save-progress inline-flex items-center gap-2" *ngIf="!isSaved" (click)="updateProgress()">
+            <i class="fas fa-save"></i>
+            <span>{{ 'updateProgress' | translate }}</span>
           </button>
           <button routerLink="/website-requirements" class="btn btn-primary save-progress"  *ngIf="!isSaved" >
              {{ 'next' | translate }}

--- a/src/app/tab/new-marketing/new-marketing.component.html
+++ b/src/app/tab/new-marketing/new-marketing.component.html
@@ -1,6 +1,6 @@
 <div class="marketing-container">
     <section class="video-section">
-      <h2><i class="fas fa-video"></i> {{ 'introductionVideo' | translate }}</h2>
+      <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
       <div class="vedio">
         <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" ></video>
       </div>
@@ -12,7 +12,7 @@
   
     <div class="business bg-white p-4 rounded-lg shadow space-y-4">
       <section class="form-section">
-        <h2 class="mb-3"><i class="fas fa-lightbulb text-primary"></i>  {{ 'yourSolutionFeatures' | translate }}</h2>
+        <h2 class="mb-3 flex items-center gap-2"><i class="fas fa-lightbulb text-primary"></i><span>{{ 'yourSolutionFeatures' | translate }}</span></h2>
         <div class="form-group mb-4">
           <label><strong>Considering the discussion we had, list three features that 
             can make your solution unique in the market?</strong>
@@ -65,7 +65,7 @@
     </div> 
     
     <section class="video-section">
-        <h2><i class="fas fa-video"></i> {{ 'marketingActivities' | translate }}</h2>
+        <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'marketingActivities' | translate }}</span></h2>
         <div class="vedio">
           <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl2}}" ></video>
         </div>

--- a/src/app/tab/new-sales/new-sales.component.html
+++ b/src/app/tab/new-sales/new-sales.component.html
@@ -1,6 +1,6 @@
 <div class="sales-strategy-container">
     <section class="video-section">
-      <h2><i class="fas fa-video"></i> {{ 'introductionVideo' | translate }}</h2>
+      <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
       <div class="vedio">
         <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" ></video>
   
@@ -17,7 +17,7 @@
       
         <!-- Video 2 Section -->
         <section class="video-section">
-            <h2><i class="fas fa-video"></i> {{ 'introductionVideo' | translate }}</h2>
+            <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
             <div class="vedio">
               <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl2}}" ></video>
         

--- a/src/app/tab/sales-strategy/sales-strategy.component.html
+++ b/src/app/tab/sales-strategy/sales-strategy.component.html
@@ -1,6 +1,6 @@
 <div class="sales-strategy-container">
   <section class="video-section">
-    <h2><i class="fas fa-video"></i> Introduction Video</h2>
+    <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
     <div class="vedio">
       <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" autoplay></video>
 

--- a/src/app/testing-your-idea/testing-your-idea.component.html
+++ b/src/app/testing-your-idea/testing-your-idea.component.html
@@ -2,7 +2,7 @@
  
    <div class="p-6 space-y-6 bg-gray-100 min-h-screen business">
     <section class="video-section">
-        <h2><i class="fas fa-video"></i> Introduction Video</h2>
+        <h2 class="flex items-center gap-2"><i class="fas fa-video"></i><span>{{ 'introductionVideo' | translate }}</span></h2>
         <div class="vedio">
           <video controls src="https://businesstools-admin.valuenationapp.com{{videoUrl}}" ></video>
     
@@ -12,8 +12,8 @@
   
       <div class="bg-white p-4 rounded-lg shadow space-y-4">
         <div>
-          <label class="block">What is your chosen Business Idea?</label>
-          <textarea [(ngModel)]="your_idea" class="w-full p-2 border rounded" placeholder="Insert your choice of a business idea"></textarea>
+          <label class="block">{{ 'chosenBusinessIdeaQuestion' | translate }}</label>
+          <textarea [(ngModel)]="your_idea" class="w-full p-2 border rounded" placeholder="{{ 'businessIdeaPlaceholder' | translate }}"></textarea>
           
         </div>
         <h2 class="text-xl font-semibold">{{ 'desirabilityTitle' | translate }}</h2>
@@ -87,15 +87,17 @@
 
 
       <div class="save-section text-center mt-2">
-        <button class="btn btn-primary save-progress" *ngIf="isSaved" (click)="save()">
-          <i class="fas fa-save"></i> {{ 'saveProgress' | translate }}
+        <button class="btn btn-primary save-progress inline-flex items-center gap-2" *ngIf="isSaved" (click)="save()">
+          <i class="fas fa-save"></i>
+          <span>{{ 'saveProgress' | translate }}</span>
         </button>
       </div>
-      <div class="update-section d-flex justify-content-around">
-        <button class="btn btn-primary save-progress"*ngIf="!isSaved" (click)="update()">
-          <i class="fas fa-save"></i> {{ 'updateProgress' | translate }}
+      <div class="update-section flex justify-around">
+        <button class="btn btn-primary save-progress inline-flex items-center gap-2" *ngIf="!isSaved" (click)="update()">
+          <i class="fas fa-save"></i>
+          <span>{{ 'updateProgress' | translate }}</span>
         </button>
-        <button class="btn btn-primary save-progress"*ngIf="!isSaved" routerLink="/market-research">
+        <button class="btn btn-primary save-progress" *ngIf="!isSaved" routerLink="/market-research">
           {{ 'next' | translate }}
         </button>
       </div>

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -86,4 +86,6 @@
   "signIn": "تسجيل الدخول"
   ,"resetInstructions": "أدخل بريدك الإلكتروني لتصلك تعليمات إعادة التعيين",
   "emailPlaceholder": "أدخل بريدك الإلكتروني"
+  ,"chosenBusinessIdeaQuestion": "ما هي فكرة العمل التي اخترتها؟"
+  ,"businessIdeaPlaceholder": "اكتب فكرتك في العمل هنا"
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -86,4 +86,6 @@
   "signIn": "Sign In"
   ,"resetInstructions": "Enter your email to receive reset instructions",
   "emailPlaceholder": "Enter your email"
+  ,"chosenBusinessIdeaQuestion": "What is your chosen Business Idea?"
+  ,"businessIdeaPlaceholder": "Insert your choice of a business idea"
 }


### PR DESCRIPTION
## Summary
- make navigation home icon accessible and remove Landing Page text
- make landing page logo clickable
- improve icon spacing & translation usage across tabs
- add example translations for new form labels

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fef3b32ac833396d3867dc69ba7ef