### PR TITLE
Add interpolation support to translation pipe

### DIFF
--- a/src/app/pipes/translate.pipe.ts
+++ b/src/app/pipes/translate.pipe.ts
@@ -4,7 +4,8 @@ import { TranslationService } from '../services/translation.service';
 @Pipe({ name: 'translate', pure: false })
 export class TranslatePipe implements PipeTransform {
   constructor(private translation: TranslationService) {}
-  transform(key: string): string {
-    return this.translation.translate(key);
+
+  transform(key: string, params?: Record<string, unknown>): string {
+    return this.translation.translate(key, params);
   }
 }

--- a/src/app/services/translation.service.ts
+++ b/src/app/services/translation.service.ts
@@ -32,8 +32,15 @@ export class TranslationService {
     return this.currentLang;
   }
 
-  translate(key: string): string {
-    return this.translations[key] || key;
+  translate(key: string, params?: Record<string, unknown>): string {
+    let result = this.translations[key] || key;
+    if (params) {
+      Object.keys(params).forEach(param => {
+        const value = String(params[param]);
+        result = result.replace(new RegExp(`{{\\s*${param}\\s*}}`, 'g'), value);
+      });
+    }
+    return result;
   }
 
   private updateDocumentDirection() {


### PR DESCRIPTION
## Summary
- allow TranslationService.translate to accept parameters for placeholders
- update TranslatePipe to forward optional parameters

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff4aea1fc83339d2c50f34959b9cd