### PR TITLE
Fix translations and RTL layout

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -23,8 +23,8 @@
           </a> -->
         </div>
       </div>
-      <button class="sign-out text-sm font-semibold" (click)="logout()" [disabled]="isLoading">
-        <i class="fas fa-sign-out-alt mr-1"></i>
+      <button class="sign-out text-sm font-semibold flex items-center gap-1" (click)="logout()" [disabled]="isLoading">
+        <i class="fas fa-sign-out-alt"></i>
         <span *ngIf="!isLoading">{{ 'signOut' | translate }}</span>
         <span *ngIf="isLoading">{{ 'loading' | translate }}</span>
       </button>

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -6,7 +6,7 @@
     <button class="menu-toggle md:hidden text-gray-600" (click)="toggleNavbar()" aria-label="Toggle navigation">
       <i class="fas fa-bars"></i>
     </button>
-    <div class="nav-links w-full md:flex md:items-center md:space-x-6 overflow-x-auto whitespace-nowrap pb-2" [ngClass]="{ 'hidden': isNavbarCollapsed, 'block': !isNavbarCollapsed, 'mt-2': !isNavbarCollapsed }">
+    <div class="nav-links w-full md:flex md:items-center md:gap-6 overflow-x-auto whitespace-nowrap pb-2" [ngClass]="{ 'hidden': isNavbarCollapsed, 'block': !isNavbarCollapsed, 'mt-2': !isNavbarCollapsed }">
       <a *ngFor="let link of navLinks"
          routerLink="{{link.path}}"
          routerLinkActive="nav-link-active"

--- a/src/app/tab/bussiness-idea/bussiness-idea.component.html
+++ b/src/app/tab/bussiness-idea/bussiness-idea.component.html
@@ -7,11 +7,12 @@
   </div>
    
     <p class="video-description">{{videoDescription}}</p>
-    <div class="mt-4">
-      <button (click)="generatePDF()" class="btn btn-primary">
-        <i class="fas fa-file-download"></i> PDF
+    <div class="mt-4 flex items-center gap-2">
+      <button (click)="generatePDF()" class="btn btn-primary inline-flex items-center gap-2">
+        <i class="fas fa-file-download"></i>
+        <span>PDF</span>
       </button>
-      <button (click)="fillDemoData()" class="btn btn-secondary ml-2">
+      <button (click)="fillDemoData()" class="btn btn-secondary">
         {{ 'showDemoData' | translate }}
       </button>
     </div>
@@ -94,7 +95,7 @@
             <i class="fas fa-robot"></i>
           </button>
         </div>
-        <small class="form-text text-muted">Describe your business idea 1</small>
+        <small class="form-text text-muted">{{ 'describeBusinessIdea' | translate }}</small>
       </div>
 
       <!-- Idea 2 -->
@@ -110,7 +111,7 @@
             <i class="fas fa-robot"></i>
           </button>
         </div>
-        <small class="form-text text-muted">Describe your business idea 2</small>
+        <small class="form-text text-muted">{{ 'describeBusinessIdea' | translate }}</small>
       </div>
 
       <!-- Idea 3 -->
@@ -126,7 +127,7 @@
             <i class="fas fa-robot"></i>
           </button>
         </div>
-        <small class="form-text text-muted">Describe your business idea 3</small>
+        <small class="form-text text-muted">{{ 'describeBusinessIdea' | translate }}</small>
       </div>
 
       <!-- Idea 4 -->
@@ -142,7 +143,7 @@
             <i class="fas fa-robot"></i>
           </button>
         </div>
-        <small class="form-text text-muted">Describe your business idea 4</small>
+        <small class="form-text text-muted">{{ 'describeBusinessIdea' | translate }}</small>
       </div>
 
       <!-- Idea 5 -->
@@ -158,7 +159,7 @@
             <i class="fas fa-robot"></i>
           </button>
         </div>
-        <small class="form-text text-muted">Describe your business idea 5</small>
+        <small class="form-text text-muted">{{ 'describeBusinessIdea' | translate }}</small>
       </div>
     </div>
   </section>

--- a/src/app/tab/financial-planing/financial-planing.component.html
+++ b/src/app/tab/financial-planing/financial-planing.component.html
@@ -58,12 +58,12 @@
           </div>
         </div>
         <div class="input-group">
-          <label class="field-label">Notes</label>
-          <textarea 
+          <label class="field-label">{{ 'notes' | translate }}</label>
+          <textarea
             class="form-control notes-input"
             rows="2"
             [(ngModel)]="cost.notes"
-            placeholder="Additional notes"
+            [placeholder]="'extraNotesPlaceholder' | translate"
           ></textarea>
         </div>
       </div>
@@ -349,12 +349,12 @@
           </button>
         </div>
         <div class="input-group">
-          <label class="field-label">Notes</label>
-          <textarea 
+          <label class="field-label">{{ 'notes' | translate }}</label>
+          <textarea
             class="form-control notes-input"
             rows="2"
             [(ngModel)]="entry.notes"
-            placeholder="Additional notes"
+            [placeholder]="'extraNotesPlaceholder' | translate"
           ></textarea>
         </div>
       </div>

--- a/src/app/tab/launch-prepration/launch-prepration.component.html
+++ b/src/app/tab/launch-prepration/launch-prepration.component.html
@@ -72,19 +72,19 @@
             </div>
           </div>
           <div class="input-group">
-            <label class="field-label">Notes</label>
-            <textarea 
+            <label class="field-label">{{ 'notes' | translate }}</label>
+            <textarea
               class="form-control notes-input"
               rows="2"
               [(ngModel)]="task.notes"
-              placeholder="Additional notes"
+              [placeholder]="'extraNotesPlaceholder' | translate"
             ></textarea>
           </div>
         </div>
       </div>
     </div>
-    <button class="btn btn-outline-primary add-btn" (click)="addTask()">
-      <i class="fas fa-plus"></i> Add Task
+    <button class="btn btn-outline-primary add-btn flex items-center gap-2" (click)="addTask()">
+      <i class="fas fa-plus"></i> {{ 'addTask' | translate }}
     </button>
   </section>
 

--- a/src/app/tab/new-business-setup/new-business-setup.component.html
+++ b/src/app/tab/new-business-setup/new-business-setup.component.html
@@ -14,8 +14,8 @@
     <!-- Legal Structure Section -->
 <!-- Legal Structure Section -->
 <section class="form-section">
-    <h2 class="text-xl font-semibold mb-2">
-      <i class="fas fa-building mr-2"></i> {{ 'legalStructure' | translate }}
+    <h2 class="text-xl font-semibold mb-2 flex items-center gap-2">
+      <i class="fas fa-building"></i> <span>{{ 'legalStructure' | translate }}</span>
     </h2>
     <p class="section-description mb-4">
       Define your business's legal structure and requirements.
@@ -88,8 +88,8 @@
   </section>
   <!-- Legal Requirements Tasks Section -->
 <section class="form-section mt-8">
-    <h2 class="text-xl font-semibold mb-4">
-      <i class="fas fa-tasks mr-2"></i> {{ 'legalRequirementsTasks' | translate }}
+    <h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+      <i class="fas fa-tasks"></i> <span>{{ 'legalRequirementsTasks' | translate }}</span>
     </h2>
   
     <div *ngFor="let task of legalStructure.requirements; let i = index" class="mb-6 p-4 border rounded bg-gray-50 relative">
@@ -141,16 +141,16 @@
       
   
     <!-- Add Task Button -->
-    <button 
+    <button
       class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 flex items-center gap-2"
       (click)="addRequirementTask()"
     >
-      <i class="fas fa-plus"></i> Add Task
+      <i class="fas fa-plus"></i> {{ 'addTask' | translate }}
     </button>
   </section>
   <div class="form-group mt-4">
-    <label><strong>Notes</strong></label>
-    <textarea [(ngModel)]="notes" name="notes" class="form-control custom-textarea" rows="3" placeholder="Any extra notes"></textarea>
+    <label><strong>{{ 'notes' | translate }}</strong></label>
+    <textarea [(ngModel)]="notes" name="notes" class="form-control custom-textarea" rows="3" [placeholder]="'extraNotesPlaceholder' | translate"></textarea>
   </div>
   
   <div class="save-section d-flex justify-content-center mt-3">

--- a/src/app/tab/new-financial/new-financial.component.html
+++ b/src/app/tab/new-financial/new-financial.component.html
@@ -39,11 +39,11 @@
       
         <!-- قسم الملاحظات -->
         <div>
-          <label class="block font-semibold mb-2">Notes</label>
-          <textarea 
+          <label class="block font-semibold mb-2">{{ 'notes' | translate }}</label>
+          <textarea
             [(ngModel)]="notes"
-            rows="6" 
-            placeholder="Add notes here"
+            rows="6"
+            [placeholder]="'extraNotesPlaceholder' | translate"
             class="w-full p-3 border border-blue-500 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-300 resize-none">
           </textarea>
         </div>

--- a/src/app/tab/new-marketing/new-marketing.component.html
+++ b/src/app/tab/new-marketing/new-marketing.component.html
@@ -20,7 +20,7 @@
   
           <div class="flex flex-col mb-4 mt-3 space-y-1">
             <label for="">Option 1 (AI Suggestions)</label>
-            <div class="flex items-start space-x-2">
+            <div class="flex items-start gap-2">
               <textarea [(ngModel)]="product_feature.options[0]" name="entry_strategy_0"
                 class="form-control custom-textarea flex-1" rows="3"
                 placeholder=""></textarea>
@@ -32,7 +32,7 @@
           
           <div class="flex flex-col mb-4 space-y-1">
             <label for="">Option 2 (AI Suggestions)</label>
-            <div class="flex items-start space-x-2">
+            <div class="flex items-start gap-2">
               <textarea [(ngModel)]="product_feature.options[1]" name="entry_strategy_1"
                 class="form-control custom-textarea flex-1" rows="3"
                 placeholder=""></textarea>
@@ -44,7 +44,7 @@
           
           <div class="flex flex-col mb-4 space-y-1">
             <label for="">Option 3 (AI Suggestions)</label>
-            <div class="flex items-start space-x-2">
+            <div class="flex items-start gap-2">
               <textarea [(ngModel)]="product_feature.options[2]" name="entry_strategy_2"
                 class="form-control custom-textarea flex-1" rows="3"
                 placeholder=""></textarea>
@@ -57,8 +57,8 @@
         </div>
   
         <div class="form-group mb-4">
-          <label><strong>Notes</strong></label>
-          <textarea [(ngModel)]="product_feature.notes" name="notes" class="form-control custom-textarea" rows="3" placeholder="Any extra notes"></textarea>
+          <label><strong>{{ 'notes' | translate }}</strong></label>
+          <textarea [(ngModel)]="product_feature.notes" name="notes" class="form-control custom-textarea" rows="3" [placeholder]="'extraNotesPlaceholder' | translate"></textarea>
         </div>
         
       </section> <!-- نهاية الفورم سيكشن -->
@@ -93,7 +93,7 @@
             <!-- الحقول -->
             <div class="form-group mb-4">
               <label><strong>1. What is the Goal/Message I want to deliver?</strong></label>
-              <div class="flex items-start space-x-2 mb-4 mt-3">
+              <div class="flex items-start gap-2 mb-4 mt-3">
                 <textarea [(ngModel)]="marketing_campaign.goal" name="goal_{{i}}"
                   class="form-control custom-textarea mt-0 flex-1" rows="3"
                   placeholder="new product, sales, events etc."></textarea>
@@ -102,7 +102,7 @@
       
             <div class="form-group mb-4">
               <label><strong>2. Who is my Audience for this campaign?</strong></label>
-              <div class="flex items-start space-x-2 mb-4 mt-3">
+              <div class="flex items-start gap-2 mb-4 mt-3">
                 <textarea [(ngModel)]="marketing_campaign.audience" name="audience_{{i}}"
                   class="form-control custom-textarea mt-0 flex-1" rows="3"
                   placeholder="new customers, young, partners etc."></textarea>
@@ -111,7 +111,7 @@
       
             <div class="form-group mb-4">
               <label><strong>3. What format do you use?</strong></label>
-              <div class="flex items-start space-x-2 mb-4 mt-3">
+              <div class="flex items-start gap-2 mb-4 mt-3">
                 <textarea [(ngModel)]="marketing_campaign.format" name="format_{{i}}"
                   class="form-control custom-textarea mt-0 flex-1" rows="3"
                   placeholder="Audio, written, Images, video, physical, graphs"></textarea>
@@ -119,8 +119,8 @@
             </div>
       
             <div class="form-group mb-4">
-              <label><strong>4. What channels you will use?</strong></label>
-              <div class="flex items-start space-x-2 mb-4 mt-3">
+              <label><strong>{{ 'channelsYouUse' | translate }}</strong></label>
+              <div class="flex items-start gap-2 mb-4 mt-3">
                 <textarea [(ngModel)]="marketing_campaign.channels" name="channels_{{i}}"
                   class="form-control custom-textarea mt-0 flex-1" rows="3"
                   placeholder="SM, Letters, phones, emails, events"></textarea>
@@ -128,17 +128,17 @@
             </div>
       
             <div class="form-group mb-4">
-              <label><strong>Notes</strong></label>
+              <label><strong>{{ 'notes' | translate }}</strong></label>
               <textarea [(ngModel)]="marketing_campaign.notes" name="notes_{{i}}"
-                class="form-control custom-textarea" rows="3" placeholder="Any extra notes"></textarea>
+                class="form-control custom-textarea" rows="3" [placeholder]="'extraNotesPlaceholder' | translate"></textarea>
             </div>
       
             <hr class="my-6">
           </section>
         </div>
       
-        <button (click)="addCampaign()" class="btn btn-primary mt-6">
-          <i class="fas fa-plus-circle"></i> Add Campaign
+        <button (click)="addCampaign()" class="btn btn-primary mt-6 inline-flex items-center gap-2">
+          <i class="fas fa-plus-circle"></i> {{ 'addCampaign' | translate }}
         </button>
       
       </div>

--- a/src/app/tab/website/website.component.html
+++ b/src/app/tab/website/website.component.html
@@ -22,7 +22,7 @@
       
           <div>
             <label class="block font-semibold mb-1">What colours represent my business best?(Type your favourite choice number)</label>
-            <div class="flex items-center space-x-2">
+            <div class="flex items-center gap-2">
               <span>My colour choice is:</span>
               <input
                 [(ngModel)]="colourChoice"
@@ -51,7 +51,7 @@
             <label class="block font-semibold mb-1">
               What Logo Style represents my business best (Type your favourite choice number)?
             </label>
-            <div class="flex items-center space-x-2">
+            <div class="flex items-center gap-2">
               <span>My Logo Style choice is:</span>
               <input
                 [(ngModel)]="logoStyleChoice"

--- a/src/app/testing-your-idea/testing-your-idea.component.html
+++ b/src/app/testing-your-idea/testing-your-idea.component.html
@@ -19,7 +19,7 @@
         <h2 class="text-xl font-semibold">{{ 'desirabilityTitle' | translate }}</h2>
         
         <label class="block">Do you think your solution is solving a real problem?</label>
-        <div class="flex space-x-4">
+        <div class="flex items-center gap-4">
           <label class="flex items-center">
             <input type="radio" name="problem" [(ngModel)]="desirability.solves_problem" value="No"> No - Go back and think of a different idea!
           </label>
@@ -32,7 +32,7 @@
         <textarea [(ngModel)]="desirability.problem_statement" class="w-full p-2 border rounded" placeholder="Define the exact problem you are trying to solve..."></textarea>
         
         <label class="block">Are your target customers currently using any other solutions?</label>
-        <div class="flex space-x-4">
+        <div class="flex items-center gap-4">
           <label class="flex items-center">
             <input type="radio" name="current_solutions" [(ngModel)]="desirability.existing_solutions_used" value="No"> No - Find out why they are not using any solutions?
           </label>
@@ -47,7 +47,7 @@
         <label class="block">Why do you think your customers would switch to your solution?</label>
         <textarea [(ngModel)]="desirability.switch_reason" class="w-full p-2 custom-textarea" placeholder="Why would they choose your solution over others?"></textarea>
         
-        <label class="block">Notes</label>
+        <label class="block">{{ 'notes' | translate }}</label>
         <textarea [(ngModel)]="desirability.notes" class="w-full p-2 border rounded" placeholder="Add any personal notes..."></textarea>
       </div>
       
@@ -60,7 +60,7 @@
         <label class="block">Does this business require any qualifications/permits?</label>
         <textarea [(ngModel)]="feasibility.qualifications_permits" class="w-full p-2 border rounded" placeholder="What qualifications/permits do we need? Can I get them?"></textarea>
         
-        <label class="block">Notes</label>
+        <label class="block">{{ 'notes' | translate }}</label>
         <textarea [(ngModel)]="feasibility.notes" class="w-full p-2 border rounded" placeholder="Add any personal notes..."></textarea>
       </div>
       
@@ -76,7 +76,7 @@
         <label class="block">Do you think you have the finances to establish this business/ or start in a small way?</label>
         <textarea [(ngModel)]="viability.finances_details" class="w-full p-2 border rounded" placeholder="Provide financial details..."></textarea>
         
-        <label class="block">Notes</label>
+        <label class="block">{{ 'notes' | translate }}</label>
         <textarea [(ngModel)]="viability.notes" class="w-full p-2 border rounded" placeholder="Add any personal notes..."></textarea>
       </div>
       

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -130,4 +130,8 @@
   "businessUpdated": "تم تحديث العمل بنجاح!",
   "planDeleted": "تم حذف الخطة!",
   "planSaved": "تم حفظ الخطة بنجاح!"
+  ,"describeBusinessIdea": "وصف فكرة عملك"
+  ,"channelsYouUse": "ما القنوات التي ستستخدمها؟"
+  ,"addCampaign": "إضافة حملة"
+  ,"addTask": "إضافة مهمة"
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -130,4 +130,8 @@
   "businessUpdated": "Business updated successfully!",
   "planDeleted": "Plan deleted!",
   "planSaved": "Plan saved successfully!"
+  ,"describeBusinessIdea": "Describe your business idea"
+  ,"channelsYouUse": "What channels you will use?"
+  ,"addCampaign": "Add Campaign"
+  ,"addTask": "Add Task"
 }


### PR DESCRIPTION
## Summary
- add missing translation keys and Arabic equivalents
- translate labels for notes, campaigns, tasks, and channels
- fix icon text spacing with gap utilities
- replace directional spacing with flex gap usage

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff7a438a48333b56b707c94375ed3