### PR TITLE
Fix env handling for OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The appli
 
 ## Environment variables
 
-Create a `.env` file in the project root with the following variable:
+Create a `.env` file in the project root or export `OPENAI_API_KEY` in your
+environment before running the application:
 
 ```bash
-OPENAI_API_KEY=your-openai-api-key
+export OPENAI_API_KEY=your-openai-api-key
 ```
 
-This key is used by `OpenAIService` to authenticate requests.
+`OpenAIService` will read this variable at runtime to authenticate requests.
 
 ## Code scaffolding
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,5 +2,11 @@ declare const process: { env: { [key: string]: string | undefined } } | undefine
 
 export const environment = {
   production: false,
-  OPENAI_API_KEY: typeof process !== 'undefined' ? process.env['OPENAI_API_KEY'] ?? '' : ''
+  OPENAI_API_KEY: ''
 };
+
+if (typeof process !== 'undefined' && process.env['OPENAI_API_KEY']) {
+  environment.OPENAI_API_KEY = process.env['OPENAI_API_KEY'];
+} else if (typeof globalThis !== 'undefined' && (globalThis as any)['OPENAI_API_KEY']) {
+  environment.OPENAI_API_KEY = (globalThis as any)['OPENAI_API_KEY'];
+}


### PR DESCRIPTION
## Summary
- make environment.ts read OPENAI_API_KEY from the runtime environment
- document how to set the API key in README

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850068df7c88333b200b82bc5fb895e