### PR TITLE
Improve language select styling

### DIFF
--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -7,3 +7,11 @@
 .sign-out:disabled {
   @apply opacity-70 cursor-not-allowed;
 }
+
+.lang-select {
+  @apply bg-blue-500 text-white border border-white rounded px-2 py-1;
+}
+
+.lang-select option {
+  @apply text-black bg-white;
+}

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -28,7 +28,7 @@
         <span *ngIf="!isLoading">{{ 'signOut' | translate }}</span>
         <span *ngIf="isLoading">{{ 'loading' | translate }}</span>
       </button>
-      <select (change)="changeLang($any($event.target).value)" [value]="currentLang" class="lang-select bg-white text-black text-sm uppercase font-semibold">
+      <select (change)="changeLang($any($event.target).value)" [value]="currentLang" class="lang-select text-sm uppercase font-semibold">
         <option value="en">EN</option>
         <option value="ar">AR</option>
         <option value="es">ES</option>


### PR DESCRIPTION
## Summary
- style language select to match header colors and keep dropdown text readable

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dc69db9c83339697599ae6fdd070