### PR TITLE
Fix Launch Milestones navigation

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -48,6 +48,7 @@ const routes: Routes = [
   { path: 'sales-strategy', component: NewSalesComponent, canActivate: [authGuard] },
   { path: 'business-setup', component: NewBusinessSetupComponent, canActivate: [authGuard] },
   { path: 'financial-planning', component: NewFinancialComponent, canActivate: [authGuard] },
+  { path: 'launch-preparation', component: LaunchPreprationComponent, canActivate: [authGuard] },
   { path: 'website-requirements', component: WebsiteComponent, canActivate: [authGuard] },
   { path: "welcome", component: WelcomeComponent },
   { path: "test", component: BussinessSetupComponent },


### PR DESCRIPTION
## Summary
- add missing route for `launch-preparation`

## Testing
- `npm test --silent --prefix .` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e7901cb8833385f3b5113d027ff6