### PR TITLE
Translate sales strategy inputs

### DIFF
--- a/src/app/tab/new-sales/new-sales.component.html
+++ b/src/app/tab/new-sales/new-sales.component.html
@@ -28,15 +28,15 @@
         <!-- Inputs Section -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
           <div>
-            <label class="block font-medium mb-1">Target Monthly Revenue ($)</label>
-            <input 
-              type="number" 
-              min="0" 
-              (focus)="calculated = false" 
-              [(ngModel)]="target_revenue" 
-              (ngModelChange)="validatePositive('target_revenue')" 
-              class="w-full border rounded p-2" 
-              placeholder="Enter revenue goal"
+            <label class="block font-medium mb-1">{{ 'targetMonthlyRevenue' | translate }}</label>
+            <input
+              type="number"
+              min="0"
+              (focus)="calculated = false"
+              [(ngModel)]="target_revenue"
+              (ngModelChange)="validatePositive('target_revenue')"
+              class="w-full border rounded p-2"
+              [placeholder]="'revenueGoalPlaceholder' | translate"
             >
             <div *ngIf="targetRevenueError" class="text-red-500 mt-1">
               Please enter a positive number greater than zero.
@@ -44,15 +44,15 @@
           </div>
         
           <div>
-            <label class="block font-medium mb-1">Unit Sale Price ($)</label>
-            <input 
-              type="number" 
-              min="0" 
-              (focus)="calculated = false" 
-              [(ngModel)]="unit_price" 
-              (ngModelChange)="validatePositive('unit_price')" 
-              class="w-full border rounded p-2" 
-              placeholder="Enter sale price"
+            <label class="block font-medium mb-1">{{ 'unitSalePrice' | translate }}</label>
+            <input
+              type="number"
+              min="0"
+              (focus)="calculated = false"
+              [(ngModel)]="unit_price"
+              (ngModelChange)="validatePositive('unit_price')"
+              class="w-full border rounded p-2"
+              [placeholder]="'salePricePlaceholder' | translate"
             >
             <div *ngIf="unitPriceError" class="text-red-500 mt-1">
               Please enter a positive number greater than zero.
@@ -60,15 +60,15 @@
           </div>
         
           <div>
-            <label class="block font-medium mb-1">Interactions Needed per Sale</label>
-            <input 
-              type="number" 
-              min="0" 
-              (focus)="calculated = false" 
-              [(ngModel)]="interactions_needed" 
-              (ngModelChange)="validatePositive('interactions_needed')" 
-              class="w-full border rounded p-2" 
-              placeholder="How many engagements to sell"
+            <label class="block font-medium mb-1">{{ 'interactionsNeededPerSale' | translate }}</label>
+            <input
+              type="number"
+              min="0"
+              (focus)="calculated = false"
+              [(ngModel)]="interactions_needed"
+              (ngModelChange)="validatePositive('interactions_needed')"
+              class="w-full border rounded p-2"
+              [placeholder]="'engagementsPerSalePlaceholder' | translate"
             >
             <div *ngIf="interactionsNeededError" class="text-red-500 mt-1">
               Please enter a positive number greater than zero.
@@ -76,16 +76,16 @@
           </div>
         
           <div>
-            <label class="block font-medium mb-1">Reach Needed per Interaction</label>
-            <input 
-              type="number" 
-              min="0" 
-              max="100" 
+            <label class="block font-medium mb-1">{{ 'reachNeededPerInteraction' | translate }}</label>
+            <input
+              type="number"
+              min="0"
+              max="100"
               (focus)="calculated = false"
-              [(ngModel)]="reach_to_interaction_percentage" 
-              (ngModelChange)="validateReachToInteraction()" 
-              class="w-full border rounded p-2" 
-              placeholder="How many reaches per engagement"
+              [(ngModel)]="reach_to_interaction_percentage"
+              (ngModelChange)="validateReachToInteraction()"
+              class="w-full border rounded p-2"
+              [placeholder]="'reachesPerEngagementPlaceholder' | translate"
             >
             <div *ngIf="reachError" class="text-red-500 mt-1">
               The value must be between 1 and 100.

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -226,6 +226,14 @@
   "bigSolutionPlaceholder": "صف رؤيتك الكبيرة لمستقبل عملك!",
   "thingsHavePlaceholder": "قم بسرد الأشياء التي تملكها بالفعل",
   "thingsNeedPlaceholder": "قم بسرد الأشياء التي يجب الحصول عليها للبدء",
-  "planMoveForwardPlaceholder": "كيف تتخيل الخطوات القادمة لعملك للوصول إلى الخطة الأكبر؟"
+  "planMoveForwardPlaceholder": "كيف تتخيل الخطوات القادمة لعملك للوصول إلى الخطة الأكبر؟",
+  "targetMonthlyRevenue": "الهدف الشهري للإيرادات ($)",
+  "revenueGoalPlaceholder": "أدخل هدف الإيرادات",
+  "unitSalePrice": "سعر بيع الوحدة ($)",
+  "salePricePlaceholder": "أدخل سعر البيع",
+  "interactionsNeededPerSale": "عدد التفاعلات المطلوبة لكل عملية بيع",
+  "engagementsPerSalePlaceholder": "كم تفاعل لإتمام البيع",
+  "reachNeededPerInteraction": "الوصول المطلوب لكل تفاعل",
+  "reachesPerEngagementPlaceholder": "كم وصول لكل تفاعل"
 
 }

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -226,5 +226,13 @@
   "bigSolutionPlaceholder": "আপনার ভবিষ্যৎ ব্যবসার বড় স্বপ্নটি বর্ণনা করুন!",
   "thingsHavePlaceholder": "আপনার কাছে যা রয়েছে তা তালিকাভুক্ত করুন",
   "thingsNeedPlaceholder": "শুরু করতে যা দরকার তা তালিকাভুক্ত করুন",
-  "planMoveForwardPlaceholder": "বড় পরিকল্পনা বাস্তবায়নে আগামী ধাপগুলো আপনি কেমন কল্পনা করেন?"
+  "planMoveForwardPlaceholder": "বড় পরিকল্পনা বাস্তবায়নে আগামী ধাপগুলো আপনি কেমন কল্পনা করেন?",
+  "targetMonthlyRevenue": "লক্ষ্য মাসিক আয় ($)",
+  "revenueGoalPlaceholder": "আয়ের লক্ষ্য লিখুন",
+  "unitSalePrice": "একক বিক্রয় মূল্য ($)",
+  "salePricePlaceholder": "বিক্রয় মূল্য লিখুন",
+  "interactionsNeededPerSale": "প্রতি বিক্রয়ে প্রয়োজনীয় ইন্টারঅ্যাকশন",
+  "engagementsPerSalePlaceholder": "বিক্রি করতে কত এনগেজমেন্ট",
+  "reachNeededPerInteraction": "প্রতি ইন্টারঅ্যাকশনে প্রয়োজনীয় রিচ",
+  "reachesPerEngagementPlaceholder": "প্রতি এনগেজমেন্টে কত রিচ"
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -224,5 +224,13 @@
   "bigSolutionPlaceholder": "Beschreibe die große Vision deines zukünftigen Unternehmens!",
   "thingsHavePlaceholder": "Liste die Dinge auf, die du bereits hast",
   "thingsNeedPlaceholder": "Liste die Dinge auf, die du für den Start benötigst",
-  "planMoveForwardPlaceholder": "Wie stellst du dir die nächsten Schritte vor, um den großen Plan zu erreichen?"
+  "planMoveForwardPlaceholder": "Wie stellst du dir die nächsten Schritte vor, um den großen Plan zu erreichen?",
+  "targetMonthlyRevenue": "Ziel-Monatsumsatz ($)",
+  "revenueGoalPlaceholder": "Umsatzziel eingeben",
+  "unitSalePrice": "Stückverkaufspreis ($)",
+  "salePricePlaceholder": "Verkaufspreis eingeben",
+  "interactionsNeededPerSale": "Benötigte Interaktionen pro Verkauf",
+  "engagementsPerSalePlaceholder": "Wie viele Kontakte pro Verkauf",
+  "reachNeededPerInteraction": "Erreichte Personen pro Interaktion",
+  "reachesPerEngagementPlaceholder": "Wie viele Reichweiten pro Kontakt"
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -224,5 +224,13 @@
   "bigSolutionPlaceholder": "Describe the big vision of your future business!",
   "thingsHavePlaceholder": "List things you already have",
   "thingsNeedPlaceholder": "List things you must get to start",
-  "planMoveForwardPlaceholder": "How would you imagine your business next few steps to grow and reach the bigger plan?"
+  "planMoveForwardPlaceholder": "How would you imagine your business next few steps to grow and reach the bigger plan?",
+  "targetMonthlyRevenue": "Target Monthly Revenue ($)",
+  "revenueGoalPlaceholder": "Enter revenue goal",
+  "unitSalePrice": "Unit Sale Price ($)",
+  "salePricePlaceholder": "Enter sale price",
+  "interactionsNeededPerSale": "Interactions Needed per Sale",
+  "engagementsPerSalePlaceholder": "How many engagements to sell",
+  "reachNeededPerInteraction": "Reach Needed per Interaction",
+  "reachesPerEngagementPlaceholder": "How many reaches per engagement"
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -224,5 +224,13 @@
   "bigSolutionPlaceholder": "¡Describe la gran visión de tu futuro negocio!",
   "thingsHavePlaceholder": "Enumera las cosas que ya tienes",
   "thingsNeedPlaceholder": "Enumera las cosas que necesitas para empezar",
-  "planMoveForwardPlaceholder": "¿Cómo imaginas los próximos pasos de tu negocio para alcanzar el plan mayor?"
+  "planMoveForwardPlaceholder": "¿Cómo imaginas los próximos pasos de tu negocio para alcanzar el plan mayor?",
+  "targetMonthlyRevenue": "Ingresos mensuales objetivo ($)",
+  "revenueGoalPlaceholder": "Ingresa la meta de ingresos",
+  "unitSalePrice": "Precio de venta por unidad ($)",
+  "salePricePlaceholder": "Ingresa el precio de venta",
+  "interactionsNeededPerSale": "Interacciones necesarias por venta",
+  "engagementsPerSalePlaceholder": "¿Cuántos contactos para vender?",
+  "reachNeededPerInteraction": "Alcance necesario por interacción",
+  "reachesPerEngagementPlaceholder": "¿Cuántos alcances por contacto?"
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -224,5 +224,13 @@
   "bigSolutionPlaceholder": "Décrivez la grande vision de votre future entreprise !",
   "thingsHavePlaceholder": "Listez les choses que vous avez déjà",
   "thingsNeedPlaceholder": "Listez les choses que vous devez obtenir pour commencer",
-  "planMoveForwardPlaceholder": "Comment imaginez-vous les prochaines étapes de votre entreprise pour atteindre le grand plan ?"
+  "planMoveForwardPlaceholder": "Comment imaginez-vous les prochaines étapes de votre entreprise pour atteindre le grand plan ?",
+  "targetMonthlyRevenue": "Revenu mensuel cible ($)",
+  "revenueGoalPlaceholder": "Entrez l'objectif de revenu",
+  "unitSalePrice": "Prix de vente unitaire ($)",
+  "salePricePlaceholder": "Entrez le prix de vente",
+  "interactionsNeededPerSale": "Interactions nécessaires par vente",
+  "engagementsPerSalePlaceholder": "Combien d'engagements pour vendre",
+  "reachNeededPerInteraction": "Portée requise par interaction",
+  "reachesPerEngagementPlaceholder": "Combien de portées par engagement"
 }

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -224,5 +224,13 @@
   "bigSolutionPlaceholder": "अपने भविष्य के व्यवसाय की बड़ी कल्पना का वर्णन करें!",
   "thingsHavePlaceholder": "वे चीजें सूचीबद्ध करें जो आपके पास पहले से हैं",
   "thingsNeedPlaceholder": "शुरू करने के लिए जिन चीजों की आवश्यकता है उन्हें सूचीबद्ध करें",
-  "planMoveForwardPlaceholder": "बड़ी योजना को पाने के लिए आप अपने व्यवसाय के अगले कदम कैसे कल्पना करते हैं?"
+  "planMoveForwardPlaceholder": "बड़ी योजना को पाने के लिए आप अपने व्यवसाय के अगले कदम कैसे कल्पना करते हैं?",
+  "targetMonthlyRevenue": "लक्षित मासिक राजस्व ($)",
+  "revenueGoalPlaceholder": "राजस्व लक्ष्य दर्ज करें",
+  "unitSalePrice": "यूनिट बिक्री मूल्य ($)",
+  "salePricePlaceholder": "बिक्री मूल्य दर्ज करें",
+  "interactionsNeededPerSale": "प्रति बिक्री आवश्यक इंटरैक्शन",
+  "engagementsPerSalePlaceholder": "बिक्री के लिए कितने एंगेजमेंट",
+  "reachNeededPerInteraction": "प्रति इंटरैक्शन आवश्यक पहुँच",
+  "reachesPerEngagementPlaceholder": "प्रति एंगेजमेंट कितनी पहुँच"
 }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -224,5 +224,13 @@
   "bigSolutionPlaceholder": "Descreva a grande visão do seu futuro negócio!",
   "thingsHavePlaceholder": "Liste as coisas que você já tem",
   "thingsNeedPlaceholder": "Liste as coisas que você precisa obter para começar",
-  "planMoveForwardPlaceholder": "Como você imagina os próximos passos do seu negócio para alcançar o grande plano?"
+  "planMoveForwardPlaceholder": "Como você imagina os próximos passos do seu negócio para alcançar o grande plano?",
+  "targetMonthlyRevenue": "Receita mensal alvo ($)",
+  "revenueGoalPlaceholder": "Insira a meta de receita",
+  "unitSalePrice": "Preço de venda por unidade ($)",
+  "salePricePlaceholder": "Insira o preço de venda",
+  "interactionsNeededPerSale": "Interações necessárias por venda",
+  "engagementsPerSalePlaceholder": "Quantos engajamentos para vender",
+  "reachNeededPerInteraction": "Alcance necessário por interação",
+  "reachesPerEngagementPlaceholder": "Quantos alcances por engajamento"
 }

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -224,5 +224,13 @@
   "bigSolutionPlaceholder": "Опишите своё глобальное видение будущего бизнеса!",
   "thingsHavePlaceholder": "Перечислите то, что у вас уже есть",
   "thingsNeedPlaceholder": "Перечислите то, что нужно получить для старта",
-  "planMoveForwardPlaceholder": "Как вы видите дальнейшие шаги бизнеса на пути к большому плану?"
+  "planMoveForwardPlaceholder": "Как вы видите дальнейшие шаги бизнеса на пути к большому плану?",
+  "targetMonthlyRevenue": "Целевой месячный доход ($)",
+  "revenueGoalPlaceholder": "Введите цель по доходу",
+  "unitSalePrice": "Цена продажи за единицу ($)",
+  "salePricePlaceholder": "Введите цену продажи",
+  "interactionsNeededPerSale": "Необходимые взаимодействия на продажу",
+  "engagementsPerSalePlaceholder": "Сколько контактов для продажи",
+  "reachNeededPerInteraction": "Охват на одно взаимодействие",
+  "reachesPerEngagementPlaceholder": "Сколько охватов на контакт"
 }

--- a/src/assets/i18n/zh.json
+++ b/src/assets/i18n/zh.json
@@ -224,5 +224,13 @@
   "bigSolutionPlaceholder": "描述您未来业务的宏伟愿景！",
   "thingsHavePlaceholder": "列出你已经拥有的东西",
   "thingsNeedPlaceholder": "列出启动所需获取的东西",
-  "planMoveForwardPlaceholder": "您认为业务接下来应如何发展以实现更大的计划？"
+  "planMoveForwardPlaceholder": "您认为业务接下来应如何发展以实现更大的计划？",
+  "targetMonthlyRevenue": "目标月收入 ($)",
+  "revenueGoalPlaceholder": "输入收入目标",
+  "unitSalePrice": "单件销售价格 ($)",
+  "salePricePlaceholder": "输入销售价格",
+  "interactionsNeededPerSale": "每次销售所需互动数",
+  "engagementsPerSalePlaceholder": "完成销售需多少互动",
+  "reachNeededPerInteraction": "每次互动所需触及人数",
+  "reachesPerEngagementPlaceholder": "每次互动需多少触及"
 }


### PR DESCRIPTION
## Summary
- localize sales strategy input labels and placeholders
- add translations for related keys across all languages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ea3e191c8333ba58ed64a41ed623