### PR TITLE
Add Arabic translations for financial planner text

### DIFF
--- a/src/app/tab/new-financial/new-financial.component.html
+++ b/src/app/tab/new-financial/new-financial.component.html
@@ -15,7 +15,7 @@
 
         <!-- رسالة التواصل -->
         <p class="italic text-sm text-blue-500 text-center">
-          If you need further help with this concept contact 
+          {{ 'furtherHelpText' | translate }}
         </p>
       
         <!-- عنوان الصفحة -->
@@ -23,7 +23,7 @@
       
         <!-- شرح المستخدم -->
         <p class="text-gray-700">
-          Please download your financial planner below, and fill up your monthly operational details
+          {{ 'financialPlannerInstructions' | translate }}
         </p>
       
        

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -68,6 +68,8 @@
   "salesFunnelCalculator": "حاسبة مسار المبيعات",
   "financialPlanningTitle": "التخطيط المالي",
   "downloadFinancialPlanner": "تنزيل مخطط مالي اكسل",
+  "furtherHelpText": "إذا كنت بحاجة إلى مزيد من المساعدة حول هذا المفهوم، تواصل معنا",
+  "financialPlannerInstructions": "يرجى تنزيل مخططك المالي أدناه، ثم ملء التفاصيل التشغيلية الشهرية",
   "legalRequirementsTasks": "مهام المتطلبات القانونية",
   "yourSolutionFeatures": "ميزات حلك",
   "getStartedTitle": "أداة تطوير الأعمال",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -68,6 +68,8 @@
   "salesFunnelCalculator": "Sales Funnel Calculator",
   "financialPlanningTitle": "Financial Planning",
   "downloadFinancialPlanner": "Download Excel Financial Planner",
+  "furtherHelpText": "If you need further help with this concept contact",
+  "financialPlannerInstructions": "Please download your financial planner below, and fill up your monthly operational details",
   "legalRequirementsTasks": "Legal Requirements Tasks",
   "yourSolutionFeatures": "Your Solution Features!",
   "getStartedTitle": "Business Development Tool",


### PR DESCRIPTION
## Summary
- localize helper text and download instructions on financial planning page
- add English and Arabic translation keys

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ef07df1083339b5179d229ce2c19